### PR TITLE
fix!: Store notes in a persistent, non-cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Default config
 ```lua
 {
   quit_key = "q",
-  notes_dir = vim.fn.stdpath("cache") .. "/jot",
+  notes_dir = vim.fn.stdpath("data") .. "/jot",
   win_opts = {
     split = "right",
     focusable = false,

--- a/lua/jot/init.lua
+++ b/lua/jot/init.lua
@@ -4,7 +4,7 @@ local M = {}
 
 M.config = {
   quit_key = "q",
-  notes_dir = vim.fn.stdpath("cache") .. "/jot",
+  notes_dir = vim.fn.stdpath("data") .. "/jot",
   win_opts = {
     split = "right",
     focusable = false,


### PR DESCRIPTION
The neovim help for `stdpath` (`:help stdpath`) says:

```
cache        String  Cache directory: arbitrary temporary
                     storage for plugins, etc.
```

On my local (linux) system, `stdpath("cache")` evaluates to `~/.cache/nvim/`.
However, things in `~/.cache` (and things called "cache" in general), can usually be deleted without losing data (!).
Especially for notes this is not the case: Deleting the notes will leave them forever gone.

Instead, use `stdpath("data")`:

```
data         String  User data directory.
```

This expands (on my linux system) to `~/.local/share/nvim`. `~/.local` is known to NOT be a cache directory, i.e., relevant data is stored there.
This is better suited than `"cache"` for the use case of notes.

---

This PR is two commits because I just used github's online-editing functionality, I think just squashing them (when merging) should be better :)

Also, really cool project! :)